### PR TITLE
Prevent multiple loadings of the graph

### DIFF
--- a/resources/js/components/Plugin.vue
+++ b/resources/js/components/Plugin.vue
@@ -156,10 +156,6 @@ export default {
     
     activated() {
       this.loadGraph();
-    },
-
-    mounted() {
-      this.loadGraph();
     }
 }
 </script>


### PR DESCRIPTION
Closes #3 

# Bug in the current version 1.0.1

1. Open Invoker
2. Go to plugins
3. Install "ER Digram Plugin"
4. Restart Invoker
5. Open Laravel project
6. Click the "ER Diagram Plugin" icon in the left project's nav
7. See relations rendered twice

![before_default](https://user-images.githubusercontent.com/6991100/169666997-a2ae8978-528d-4fb2-93f0-0b29616f938e.png)

## You can worsen the state

1. Click (after all the steps above) on a different menu option in the left project's nav
2. Click again the "ER Diagram Plugin" Icon

Now each relation is rendered three times. Repeat this for additional rendering to your liking 😅 

![before_repetition](https://user-images.githubusercontent.com/6991100/169667004-af8fb46b-6f62-40c2-8377-2f0c27ec5d4d.png)

# Solution

IMHO: The call to render the graph in the `mount` method seems not to be needed at all. 

After removing it, none of the steps above are producing error states for me anymore.

![after](https://user-images.githubusercontent.com/6991100/169667042-401f4928-eaeb-413e-923d-732a680cdce2.png)

# Disclaimer

JS is not my daily business. If there are internal components depending on the `mount` method maybe keep the `mount` method and remove the `activated` method then. 🤷🏻 😁 
